### PR TITLE
qemu-xilinx-native/qemu-xilinx-system-native: Delete PACKAGECONFIG option for jack

### DIFF
--- a/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-native_2022.1.bb
+++ b/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-native_2022.1.bb
@@ -5,3 +5,6 @@ EXTRA_OECONF:append = " --target-list=${@get_qemu_usermode_target_list(d)} --dis
 
 PROVIDES = "qemu-native"
 PACKAGECONFIG ??= "pie"
+
+# oe-core 27260be3 introduces jack that is not available on xilinx
+PACKAGECONFIG[jack] = ""

--- a/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-system-native_2022.1.bb
+++ b/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-system-native_2022.1.bb
@@ -6,6 +6,9 @@ PACKAGECONFIG ??= "fdt alsa kvm pie"
 
 PACKAGECONFIG:remove = "${@'kvm' if not os.path.exists('/usr/include/linux/kvm.h') else ''}"
 
+# oe-core 27260be3 introduces jack that is not available on xilinx
+PACKAGECONFIG[jack] = ""
+
 DEPENDS += "pixman-native qemu-xilinx-native bison-native ninja-native meson-native"
 
 do_install:append() {


### PR DESCRIPTION
Oe-core [1] introduces jack that is not available on Xilinx

```
DEBUG: Executing shell function do_configure
ERROR: unknown option --disable-jack
Try '/srv/oe/build/tmp-lmp/work/x86_64-linux/qemu-xilinx-native/v6.1.0-xilinx-v2022.1+gitAUTOINC+52a9b22fae-r0/git/configure --help' for more information | WARNING: exit code 1 from a shell command.
INFO: recipe qemu-xilinx-native-v6.1.0-xilinx-v2022.1+gitAUTOINC+52a9b22fae-r0: task do_configure: Failed
```

[1] https://git.openembedded.org/openembedded-core/commit/?id=27260be388f7f9f324ff405e7d8e254925b4ae90&h=kirkstone

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>