### PR TITLE
qemu-xilinx-native/qemu-xilinx-system-native: Delete PACKAGECONFIG option for png

### DIFF
--- a/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-native_2022.1.bb
+++ b/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-native_2022.1.bb
@@ -8,3 +8,5 @@ PACKAGECONFIG ??= "pie"
 
 # oe-core 27260be3 introduces jack that is not available on xilinx
 PACKAGECONFIG[jack] = ""
+# oe-core 34afdd0b introduces png that is not available on xilinx
+PACKAGECONFIG[png] = ""

--- a/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-system-native_2022.1.bb
+++ b/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-system-native_2022.1.bb
@@ -8,6 +8,8 @@ PACKAGECONFIG:remove = "${@'kvm' if not os.path.exists('/usr/include/linux/kvm.h
 
 # oe-core 27260be3 introduces jack that is not available on xilinx
 PACKAGECONFIG[jack] = ""
+# oe-core 34afdd0b introduces png that is not available on xilinx
+PACKAGECONFIG[png] = ""
 
 DEPENDS += "pixman-native qemu-xilinx-native bison-native ninja-native meson-native"
 


### PR DESCRIPTION
Oe-core [1] introduces png that is not available on Xilinx
```
DEBUG: Executing shell function do_configure
ERROR: unknown option --disable-png
Try '/srv/oe/build/tmp-lmp/work/x86_64-linux/qemu-xilinx-native/v6.1.0-xilinx-v2022.1+gitAUTOINC+52a9b22fae-r0/git/configure --help' for more information | WARNING: exit code 1 from a shell command.
INFO: recipe qemu-xilinx-native-v6.1.0-xilinx-v2022.1+gitAUTOINC+52a9b22fae-r0: task do_configure: Failed
```
[1] https://git.openembedded.org/openembedded-core/commit/?id=34afdd0bf5e2810d440bcd378ba1023159c2b2d0

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>